### PR TITLE
Use hook rather than preexec.

### DIFF
--- a/titles.plugin.zsh
+++ b/titles.plugin.zsh
@@ -15,12 +15,12 @@ function update_title() {
 }
 
 # called just before the prompt is printed
-function precmd() {
+function _zsh_title__precmd() {
   update_title "zsh" "%20<...<%~"
 }
 
 # called just before a command is executed
-function preexec() {
+function _zsh_title__preexec() {
   local -a cmd; cmd=(${(z)1})             # Re-parse the command line
 
   # Construct a command that will output the desired job number.
@@ -30,3 +30,7 @@ function preexec() {
   esac
   update_title "$cmd" "%20<...<%~"
 }
+
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd _zsh_title__precmd
+add-zsh-hook preexec _zsh_title__preexec


### PR DESCRIPTION
This allows zsh-title to cooperate with other plugins that want to use `preexec`.
