### PR TITLE
Make the 'a' variable local.

### DIFF
--- a/titles.plugin.zsh
+++ b/titles.plugin.zsh
@@ -4,6 +4,7 @@
 # Update terminal/tmux window titles based on location/command
 
 function update_title() {
+  local a
   # escape '%' in $1, make nonprintables visible
   a=${(V)1//\%/\%\%}
   a=$(print -n "%20>...>$a" | tr -d "\n")


### PR DESCRIPTION
The `a` variable is currently declared global. It will overwrite a variable with the same name used in an interactive session. For example:

```
a=1
echo $a
```

will output:

```
%20>...>echo $a
```

instead of expected:

```
1
```

This is wrong. Fix it by changing variable scope to local.
