### PR TITLE
Fix prompt expansion with PROMPT_SUBST enabled

### DIFF
--- a/titles.plugin.zsh
+++ b/titles.plugin.zsh
@@ -9,9 +9,9 @@ function update_title() {
   a=${(V)1//\%/\%\%}
   a=$(print -n "%20>...>$a" | tr -d "\n")
   if [[ -n "$TMUX" ]]; then
-    print -Pn "\ek$a:$2\e\\"
+    print -n "\ek${(%)a}:${(%)2}\e\\"
   elif [[ "$TERM" =~ "xterm*" ]]; then
-    print -Pn "\e]0;$a:$2\a"
+    print -n "\e]0;${(%)a}:${(%)2}\a"
   fi
 }
 


### PR DESCRIPTION
If the PROMPT_SUBST option is set, the string passed to `print -P`
is subjected to command substitution. Depending on command line, this
may lead to execution of commands / strings not really meant for
execution. For example:

```
setopt prompt_subst

echo '$(foo)'
update_title:8: command not found: foo

cd 'test`dir'
update_title:8: parse error
```

Since the only prompt expansion we care about are the percent escapes,
replace the `-P` option with parameter expansion flag `(%)`.
