### PR TITLE
Add support for rxvt-unicode / urxvt

### DIFF
--- a/titles.plugin.zsh
+++ b/titles.plugin.zsh
@@ -16,6 +16,8 @@ function update_title() {
     print -n "\ek${(%)a}:${(%)2}\e\\"
   elif [[ "$TERM" =~ "xterm*" ]]; then
     print -n "\e]0;${(%)a}:${(%)2}\a"
+  elif [[ "$TERM" =~ "^rxvt-unicode.*" ]]; then
+    printf '\33]2;%s:%s\007' ${(%)a} ${(%)2}
   fi
 }
 


### PR DESCRIPTION
Add support for the rxvt-unicode / urxvt terminal emulator.

`printf` command copied from the manual: https://linux.die.net/man/7/urxvt