### PR TITLE
When using tmux, check TERM before printing title

### DIFF
--- a/titles.plugin.zsh
+++ b/titles.plugin.zsh
@@ -10,7 +10,7 @@ function update_title() {
   a=$(print -n "%20>...>$a")
   # remove newlines
   a=${a//$'\n'/}
-  if [[ -n "$TMUX" ]]; then
+  if [[ -n "$TMUX" ]] && [[ $TERM == screen* ]]; then
     print -n "\ek${(%)a}:${(%)2}\e\\"
   elif [[ "$TERM" =~ "screen*" ]]; then
     print -n "\ek${(%)a}:${(%)2}\e\\"

--- a/titles.plugin.zsh
+++ b/titles.plugin.zsh
@@ -10,7 +10,7 @@ function update_title() {
   a=$(print -n "%20>...>$a")
   # remove newlines
   a=${a//$'\n'/}
-  if [[ -n "$TMUX" ]] && [[ $TERM == screen* ]]; then
+  if [[ -n "$TMUX" ]] && [[ $TERM == screen* || $TERM == tmux* ]]; then
     print -n "\ek${(%)a}:${(%)2}\e\\"
   elif [[ "$TERM" =~ "screen*" ]]; then
     print -n "\ek${(%)a}:${(%)2}\e\\"


### PR DESCRIPTION
I've noticed three related problems. I see titles appearing in between commands I type under the following circumstances

* Using `tmux`
    - I launch `emacs` and use a `term` or `ansi-term`
    - I launch `vim` and start up a `:term`
    - From WSL, I launch a `gnome-terminal` using `X`

In all three cases, the environment variable `TMUX` has been set, but it's not really appropriate to print titles. In the case of the `gnome-terminal`, it inherits `TMUX` from the terminal that launched it, but it's not running `tmux`.

I think the solution is to test not just whether `TMUX` has been set, but also whether `TERM` has been set to [one of the correct terminal types](https://github.com/tmux/tmux/wiki/FAQ), namely `screen*` or `tmux*`.

What do you think?
