### PR TITLE
Avoid subshell

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ and the command being run.  See the following screenshot for examples of both:
 
 ![screenshot](https://raw.githubusercontent.com/jreese/zsh-titles/master/screenshot.png)
 
+Note: Since tmux v2.7, the option that allows tmux windows to be automatically rename was turned off by default. To turn it on, add
+
+    set -g allow-rename on
+
+to your `.tmux.conf`.
+
 ## copyright
 
 zsh-titles is copyright 2015 John Reese, and licensed under the MIT license.

--- a/titles.plugin.zsh
+++ b/titles.plugin.zsh
@@ -7,7 +7,8 @@ function update_title() {
   local a
   # escape '%' in $1, make nonprintables visible
   a=${(V)1//\%/\%\%}
-  a=$(print -n "%20>...>$a")
+  print -nz "%20>...>$a"
+  read -rz a
   # remove newlines
   a=${a//$'\n'/}
   if [[ -n "$TMUX" ]] && [[ $TERM == screen* || $TERM == tmux* ]]; then


### PR DESCRIPTION
Here's another trick your Windows users will appreciate. Subshells created by command substitution are incredibly slow in Windows (it was not designed with Unix-style forking in mind). If I time [line 10](https://github.com/jreese/zsh-titles/blob/b89814d91326844219ee4270506691f678a86911/titles.plugin.zsh#L10) in Windows

    time ( a=$(print -n "%20>...>$a") )

it takes about 115ms. If I rephrase it as

    time ( print -nz "%20>...>$a"; read -rz a )

it only takes 56ms. The technique of writing an output to the `zle` editing buffer and the reading it back into a variable looks a bit obscure, but it's [apparently how `zsh` manages stunts like `printf -v`](http://www.zsh.org/mla/users/2018/msg00610.html) itself. I've used this technique in my [zsh-z plugin](https://github.com/agkozak/zsh-z), and I haven't had a problem yet.

I also updated the `README.md` with a note about how the `tmux` `allow-rename` option was turned off by default in v2.7 -- people will need to turn it on when they upgrade.