### PR TITLE
Symlinked plugin file to match the repo name for oh-my-zsh compatibility

### DIFF
--- a/zsh-titles.plugin.zsh
+++ b/zsh-titles.plugin.zsh
@@ -1,0 +1,1 @@
+titles.plugin.zsh


### PR DESCRIPTION
Renamed plugin file to match the repo name to conform to the 'custom' loading method for compatibility with oh-my-zsh:

https://github.com/ohmyzsh/ohmyzsh/wiki/Customization#overriding-and-adding-plugins