### PR TITLE
add 'wezterm' to the supported TERM values for OSC-0

### DIFF
--- a/titles.plugin.zsh
+++ b/titles.plugin.zsh
@@ -15,7 +15,7 @@ function update_title() {
     print -n "\ek${(%)a}:${(%)2}\e\\"
   elif [[ "$TERM" =~ "screen*" ]]; then
     print -n "\ek${(%)a}:${(%)2}\e\\"
-  elif [[ "$TERM" =~ "xterm*" || "$TERM" = "alacritty" || "$TERM" =~ "st*" ]]; then
+  elif [[ "$TERM" =~ "xterm*" || "$TERM" =~ "alacritty|wezterm" || "$TERM" =~ "st*" ]]; then
     print -n "\e]0;${(%)a}:${(%)2}\a"
   elif [[ "$TERM" =~ "^rxvt-unicode.*" ]]; then
     printf '\33]2;%s:%s\007' ${(%)a} ${(%)2}


### PR DESCRIPTION
i there - I had this patched for myself locally, but realized I might as well PR it back just in case you run into any other wezterm users running into this.

[WezTerm](https://wezfurlong.org/wezterm/) by default sets TERM to `xterm` or `xterm-256color`, so it normally works fine with this plugin. However, users can optionally install WezTerm terminfo and set `TERM=wezterm` to improve integration with certain curses-based programs and get some [extra bells and whistles like curly underlines](https://wezfurlong.org/wezterm/faq.html?highlight=terminfo#how-do-i-enable-undercurl-curly-underlines), which in my case broke the auto-titling. This makes sure those escapes will still be sent.

Thanks!